### PR TITLE
moved Google API Key to ENV variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+
+# Local env file for dotenv-rails
+.env
+

--- a/Gemfile
+++ b/Gemfile
@@ -56,5 +56,7 @@ group :development, :test do
   gem 'factory_girl_rails'
   gem 'faker'
   gem 'shoulda-matchers'
+
+  gem 'dotenv-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,9 @@ GEM
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
+    dotenv (2.0.0)
+    dotenv-rails (2.0.0)
+      dotenv (= 2.0.0)
     erubis (2.7.0)
     execjs (2.2.2)
     factory_girl (4.5.0)
@@ -239,6 +242,7 @@ DEPENDENCIES
   byebug
   coffee-rails (~> 4.1.0)
   devise
+  dotenv-rails
   factory_girl_rails
   faker
   jquery-rails

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+  def google_map_url
+    api_key = ENV['GOOGLE_MAPS_API_KEY'] || 'AIzaSyB-t8XMvm6aOqxvFsrI8fd9hqiMz5hkzRY'
+    zoom = 12
+    place = 'Vulcan'
+    city = 'Birmingham'
+    state = 'AL'
+    location = "#{place},#{city}+#{state}"
+    "https://www.google.com/maps/embed/v1/place?key=#{api_key}&zoom=#{zoom}&q=#{location}"
+  end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -26,7 +26,7 @@
   <!--map-->
   <div id="mapcard">
     <div id="map">
-      <iframe width="100%" height="600" frameborder="0" style="border:0" src="https://www.google.com/maps/embed/v1/place?key=AIzaSyB-t8XMvm6aOqxvFsrI8fd9hqiMz5hkzRY&zoom=12&q=Vulcan,Birmingham+AL"></iframe>
+      <iframe width="100%" height="600" frameborder="0" style="border:0" src="<%= google_map_url %>"></iframe>
     </div>
   </div>
   <!--end map-->

--- a/spec/helpers/application_helper_test.rb
+++ b/spec/helpers/application_helper_test.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe ApplicationHelper do
+  context "#google_map_url" do
+    context "given Google Map API Key ENV" do
+      it "returns a google map API url" do
+        ENV['GOOGLE_MAPS_API_KEY'] = "gmapi_key_777"
+        expect(google_map_url).to eq('https://www.google.com/maps/embed/v1/place?key=gmapi_key_777&zoom=12&q=Vulcan,Birmingham+AL')
+      end
+    end
+  end
+end


### PR DESCRIPTION
defaults back to original key
leverage dotenv gem to load .env in dev/test
